### PR TITLE
correct example in the man

### DIFF
--- a/man/swarm.1
+++ b/man/swarm.1
@@ -444,7 +444,7 @@ zcat myfile.fasta.gz | \\
         \-t 4 \\
         \-f \\
         \-w myfile.representatives.fasta \\
-        \-o /dev/null
+        \-o myfile.swarms
 .RE
 .EE
 .\" ============================================================================


### PR DESCRIPTION
I noticed a small inconsistency in the manual regarding the output destination of clusters generated by the swarm command. 
The manual states, "Clusters are written to the file myfile.swarms", but in the example this data is actually being sent to `/dev/null`.

This PR updates the swarm command described in the example.

The previous command
```
zcat myfile.fasta.gz | \
                  swarm \
                      -t 4 \
                      -f \
                      -w myfile.representatives.fasta \
                      -o /dev/null
```

was updated to
```
zcat myfile.fasta.gz | \
                  swarm \
                      -t 4 \
                      -f \
                      -w myfile.representatives.fasta \
                      -o myfile.swarms
```