### PR TITLE
Add bash and zsh shell auto-completion for swarm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@
 PROG := bin/swarm
 MAN  := man/swarm.1
 SRC  := src
+BASH_COMPLETION := completion/swarm.bash
+ZSH_COMPLETION  := completion/_swarm
 
 PREFIX ?= /usr/local
 exec_prefix := $(PREFIX)
@@ -31,6 +33,8 @@ datarootdir := $(PREFIX)/share
 bindir      := $(exec_prefix)/bin
 mandir      := $(datarootdir)/man
 man1dir     := $(mandir)/man1
+bashcompdir ?= $(datarootdir)/bash-completion/completions
+zshcompdir  ?= $(datarootdir)/zsh/site-functions
 
 INSTALL         ?= /usr/bin/install
 INSTALL_PROGRAM ?= $(INSTALL) -m 0755
@@ -38,7 +42,7 @@ INSTALL_DATA    ?= $(INSTALL) -m 0644
 MKDIR_P         ?= $(INSTALL) -d
 RM              ?= rm -f
 
-.PHONY: all swarm install uninstall clean distclean $(PROG)
+.PHONY: all swarm install install-completion uninstall clean distclean $(PROG)
 
 all: swarm
 
@@ -47,15 +51,23 @@ swarm: $(PROG)
 $(PROG):
 	$(MAKE) -C $(SRC)
 
-install: $(PROG) $(MAN)
+install: $(PROG) $(MAN) install-completion
 	$(MKDIR_P) $(DESTDIR)$(bindir)
 	$(INSTALL_PROGRAM) $(PROG) $(DESTDIR)$(bindir)
 	$(MKDIR_P) $(DESTDIR)$(man1dir)
 	$(INSTALL_DATA) $(MAN) $(DESTDIR)$(man1dir)
 
+install-completion: $(BASH_COMPLETION) $(ZSH_COMPLETION)
+	$(MKDIR_P) $(DESTDIR)$(bashcompdir)
+	$(INSTALL_DATA) $(BASH_COMPLETION) $(DESTDIR)$(bashcompdir)/swarm
+	$(MKDIR_P) $(DESTDIR)$(zshcompdir)
+	$(INSTALL_DATA) $(ZSH_COMPLETION) $(DESTDIR)$(zshcompdir)/_swarm
+
 uninstall:
 	$(RM) $(DESTDIR)$(bindir)/$(notdir $(PROG))
 	$(RM) $(DESTDIR)$(man1dir)/$(notdir $(MAN))
+	$(RM) $(DESTDIR)$(bashcompdir)/swarm
+	$(RM) $(DESTDIR)$(zshcompdir)/_swarm
 
 clean:
 	$(MAKE) -C $(SRC) clean

--- a/README.md
+++ b/README.md
@@ -181,6 +181,36 @@ swarm --version  # check
 ```
 
 
+## Shell auto-completion ##
+
+**swarm** ships with completion scripts for **bash** and **zsh** (in
+the [`completion/`](./completion) directory). Once installed, pressing
+the <kbd>Tab</kbd> key while typing a **swarm** command suggests the
+available options; options that expect a file name (e.g. `--output-file`)
+complete file names, and the positional FASTA argument completes file
+names too.
+
+The completion scripts are installed automatically by `make install`,
+in the standard locations (`$PREFIX/share/bash-completion/completions`
+and `$PREFIX/share/zsh/site-functions`). You can override these with
+the `BASH_COMPLETION_DIR` and `ZSH_COMPLETION_DIR` variables:
+
+```sh
+make install BASH_COMPLETION_DIR=/etc/bash_completion.d
+```
+
+To enable completion manually, without installing system-wide:
+
+```sh
+# bash (add to ~/.bashrc)
+source /path/to/swarm/completion/swarm.bash
+
+# zsh (add the directory to your $fpath, before `compinit`, in ~/.zshrc)
+fpath=(/path/to/swarm/completion $fpath)
+autoload -Uz compinit && compinit
+```
+
+
 ## Prepare amplicon fasta files ##
 
 To facilitate the use of **swarm**, we provide examples of shell

--- a/completion/_swarm
+++ b/completion/_swarm
@@ -1,0 +1,38 @@
+#compdef swarm
+#
+# zsh completion for swarm
+#
+# Installation (handled automatically by `make install`):
+#   copy this file (named `_swarm`) into a directory listed in your $fpath,
+#   e.g. /usr/share/zsh/site-functions, then restart zsh.
+
+_swarm() {
+    _arguments -s -S \
+        '(-h --help)'{-h,--help}'[display help and exit]' \
+        '(-v --version)'{-v,--version}'[display version information and exit]' \
+        '(-t --threads)'{-t,--threads}'[number of threads to use]:threads:' \
+        '(-d --differences)'{-d,--differences}'[resolution (number of differences)]:differences:' \
+        '(-n --no-otu-breaking)'{-n,--no-otu-breaking}'[never break clusters (not recommended!)]' \
+        '(-b --boundary)'{-b,--boundary}'[min mass of large clusters]:boundary:' \
+        '(-c --ceiling)'{-c,--ceiling}'[max memory in MB for Bloom filter]:ceiling:' \
+        '(-f --fastidious)'{-f,--fastidious}'[link nearby low-abundance swarms]' \
+        '(-y --bloom-bits)'{-y,--bloom-bits}'[bits used per Bloom filter entry]:bits:' \
+        '(-a --append-abundance)'{-a,--append-abundance}'[value to use when abundance is missing]:abundance:' \
+        '(-i --internal-structure)'{-i,--internal-structure}'[write internal cluster structure to file]:filename:_files' \
+        '(-j --network-file)'{-j,--network-file}'[dump sequence network to file]:filename:_files' \
+        '(-l --log)'{-l,--log}'[log to file, not to stderr]:filename:_files' \
+        '(-o --output-file)'{-o,--output-file}'[output result to file]:filename:_files' \
+        '(-r --mothur)'{-r,--mothur}'[output using mothur-like format]' \
+        '(-s --statistics-file)'{-s,--statistics-file}'[dump cluster statistics to file]:filename:_files' \
+        '(-u --uclust-file)'{-u,--uclust-file}'[output using UCLUST-like format to file]:filename:_files' \
+        '(-w --seeds)'{-w,--seeds}'[write cluster representatives to FASTA file]:filename:_files' \
+        '(-z --usearch-abundance)'{-z,--usearch-abundance}'[abundance annotation in usearch style]' \
+        '(-m --match-reward)'{-m,--match-reward}'[reward for nucleotide match]:reward:' \
+        '(-p --mismatch-penalty)'{-p,--mismatch-penalty}'[penalty for nucleotide mismatch]:penalty:' \
+        '(-g --gap-opening-penalty)'{-g,--gap-opening-penalty}'[gap open penalty]:penalty:' \
+        '(-e --gap-extension-penalty)'{-e,--gap-extension-penalty}'[gap extension penalty]:penalty:' \
+        '(-x --disable-sse3)'{-x,--disable-sse3}'[disable SSE3 and later x86 instructions]' \
+        '*:FASTA file:_files'
+}
+
+_swarm "$@"

--- a/completion/swarm.bash
+++ b/completion/swarm.bash
@@ -1,0 +1,73 @@
+# bash completion for swarm        -*- shell-script -*-
+#
+# Provides tab-completion of swarm's options and file arguments.
+#
+# Installation (handled automatically by `make install`):
+#   copy this file to one of the bash-completion lookup directories, e.g.
+#     /usr/share/bash-completion/completions/swarm
+#   or source it from your ~/.bashrc:
+#     source /path/to/swarm.bash
+
+_swarm()
+{
+    local cur prev
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    # Fallback for systems without the bash-completion package: a minimal
+    # _filedir that completes files and directories.
+    if ! declare -F _filedir >/dev/null 2>&1; then
+        _filedir()
+        {
+            COMPREPLY=( $(compgen -f -- "$cur") )
+        }
+    fi
+
+    # All recognised options, short and long.
+    local all_opts="\
+-a -b -c -d -e -f -g -h -i -j -l -m -n -o -p -r -s -t -u -v -w -x -y -z \
+--append-abundance --boundary --ceiling --differences --gap-extension-penalty \
+--fastidious --gap-opening-penalty --help --internal-structure --log \
+--network-file --match-reward --no-otu-breaking --output-file --mismatch-penalty \
+--mothur --statistics-file --threads --uclust-file --version --seeds \
+--disable-sse3 --bloom-bits --usearch-abundance"
+
+    # Options whose argument is a file name -> complete with files.
+    case "$prev" in
+        -i|--internal-structure|\
+        -j|--network-file|\
+        -l|--log|\
+        -o|--output-file|\
+        -s|--statistics-file|\
+        -u|--uclust-file|\
+        -w|--seeds)
+            _filedir
+            return 0
+            ;;
+        # Options whose argument is an integer -> no value suggestion.
+        -a|--append-abundance|\
+        -b|--boundary|\
+        -c|--ceiling|\
+        -d|--differences|\
+        -e|--gap-extension-penalty|\
+        -g|--gap-opening-penalty|\
+        -m|--match-reward|\
+        -p|--mismatch-penalty|\
+        -t|--threads|\
+        -y|--bloom-bits)
+            return 0
+            ;;
+    esac
+
+    # Complete option names when the current word starts with a dash.
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "$all_opts" -- "$cur") )
+        return 0
+    fi
+
+    # Otherwise complete the positional FASTA file argument with file names.
+    _filedir
+    return 0
+}
+complete -F _swarm swarm


### PR DESCRIPTION
Implements tab-completion of swarm's command-line options and file arguments for bash and zsh, as requested in the enhancement issue.

- completion/swarm.bash: bash completion (complete -F)
- completion/_swarm: zsh completion (#compdef, _arguments)
- FILENAME options complete file names; INTEGER options offer no value suggestion; the positional FASTA argument completes file names
- Makefile: install/uninstall the scripts to standard locations (bash-completion completions dir and zsh site-functions); paths overridable via bashcompdir/zshcompdir
- README: document installation and manual enablement